### PR TITLE
MGDAPI-7052 bump CRO submodule with CVE fixes and sync drift-cache

### DIFF
--- a/drift-cache/cloud-resource-operator/Dockerfile
+++ b/drift-cache/cloud-resource-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.9 AS builder
 
 # this is required for podman
 USER root


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/MGDAPI-7052